### PR TITLE
In PHP when float is used as array key, it's truncated to integer

### DIFF
--- a/boxing.class.php
+++ b/boxing.class.php
@@ -336,11 +336,11 @@ class boxing {
 
 		foreach ($array as $item) {
 
-			$tmp_array[$item["diff"]][] = $item;
+			$tmp_array[(string)$item["diff"]][] = $item;
 
 		}
 
-		krsort($tmp_array);
+		krsort($tmp_array, SORT_NUMERIC);
 
 		$array = array();
 


### PR DESCRIPTION
From: http://www.php.net/manual/en/language.types.array.php

<blockquote>Floats in key are truncated to integer.</blockquote>


This causes problems when using floats as measurements when using this class.

I've created a patch to resolve this. It seems to work for me.
